### PR TITLE
Allow for other CENC schemes

### DIFF
--- a/libavformat/dashenc.c
+++ b/libavformat/dashenc.c
@@ -1468,7 +1468,6 @@ static int dash_init(AVFormatContext *s)
                 as->ambiguous_frame_rate = 1;
             }
             c->has_video = 1;
-
         }
 
         /* Calculate the seg_duration in time_base units */
@@ -1479,7 +1478,7 @@ static int dash_init(AVFormatContext *s)
         av_log(s, AV_LOG_DEBUG, "HAPPY seg_duration_ts=%lld mod=%lld\n", c->seg_duration_ts,
             c->seg_duration * s->streams[i]->time_base.den % (1000000 * s->streams[i]->time_base.num));
 #endif
-        av_log(s, AV_LOG_DEBUG, "seg_duration_ts=%ld \n", c->seg_duration_ts);
+        av_log(s, AV_LOG_DEBUG, "seg_duration_ts=%lld \n", c->seg_duration_ts);
 
         set_codec_str(s, st->codecpar, &st->avg_frame_rate, os->codec_str,
                       sizeof(os->codec_str));
@@ -2059,7 +2058,7 @@ static const AVOption options[] = {
     { "ignore_io_errors", "Ignore IO errors during open and write. Useful for long-duration runs with network output", OFFSET(ignore_io_errors), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, E },
     { "lhls", "Enable Low-latency HLS(Experimental). Adds #EXT-X-PREFETCH tag with current segment's URI", OFFSET(lhls), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, E },
     { "start_segment", "Specify the index of the first segment (which by default is 1)", OFFSET(start_segment), AV_OPT_TYPE_INT, { .i64 = 1 }, 0, INT_MAX, E },
-    { "encryption_scheme", "Configures the Common Encryption scheme, allowed values are none, cenc-aes-ctr", OFFSET(encryption_scheme_str), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
+    { "encryption_scheme", "Configures the Common Encryption scheme, allowed values are none, cenc, cbc1, cens, cbcs", OFFSET(encryption_scheme_str), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
     { "encryption_key", "The media encryption key (hex)", OFFSET(encryption_key), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
     { "encryption_kid", "The media encryption key identifier (hex)", OFFSET(encryption_kid), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
     { "hls_enc", "enable AES128 encryption support", OFFSET(aes_encrypt), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, E},

--- a/libavformat/movenc.c
+++ b/libavformat/movenc.c
@@ -6180,22 +6180,20 @@ static int mov_init(AVFormatContext *s)
         return AVERROR(ENOMEM);
 
     if (mov->encryption_scheme_str != NULL && strcmp(mov->encryption_scheme_str, "none") != 0) {
-        if (strcmp(mov->encryption_scheme_str, "cenc-aes-ctr") == 0) {
-            mov->encryption_scheme = MOV_ENC_CENC_AES_CTR;
-
+        if (strcmp(mov->encryption_scheme_str, "cenc") == 0) {
+            mov->encryption_scheme = MOV_ENC_CENC;
             if (mov->encryption_key_len != AES_CTR_KEY_SIZE) {
                 av_log(s, AV_LOG_ERROR, "Invalid encryption key len %d expected %d\n",
                     mov->encryption_key_len, AES_CTR_KEY_SIZE);
                 return AVERROR(EINVAL);
             }
-
             if (mov->encryption_kid_len != CENC_KID_SIZE) {
                 av_log(s, AV_LOG_ERROR, "Invalid encryption kid len %d expected %d\n",
                     mov->encryption_kid_len, CENC_KID_SIZE);
                 return AVERROR(EINVAL);
             }
         } else {
-            av_log(s, AV_LOG_ERROR, "unsupported encryption scheme %s\n",
+            av_log(s, AV_LOG_ERROR, "Unsupported encryption scheme %s\n",
                 mov->encryption_scheme_str);
             return AVERROR(EINVAL);
         }
@@ -6341,7 +6339,7 @@ static int mov_init(AVFormatContext *s)
 
         avpriv_set_pts_info(st, 64, 1, track->timescale);
 
-        if (mov->encryption_scheme == MOV_ENC_CENC_AES_CTR) {
+        if (mov->encryption_scheme == MOV_ENC_CENC) {
             ret = ff_mov_cenc_init(&track->cenc, mov->encryption_key,
                 track->par->codec_id == AV_CODEC_ID_H264, s->flags & AVFMT_FLAG_BITEXACT);
             if (ret)

--- a/libavformat/movenc.h
+++ b/libavformat/movenc.h
@@ -167,7 +167,10 @@ typedef struct MOVTrack {
 
 typedef enum {
     MOV_ENC_NONE = 0,
-    MOV_ENC_CENC_AES_CTR,
+    MOV_ENC_CENC,
+    MOV_ENC_CBC1,
+    MOV_ENC_CENS,
+    MOV_ENC_CBCS,
 } MOVEncryptionScheme;
 
 typedef enum {


### PR DESCRIPTION
Use cenc, cbc1, cens, and cbcs instead of cenc-aes-ctr